### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: generic
+
+os:
+  - linux
+  - osx
+
+env:
+  - JULIA_VERSION=0.6    # oldest support
+  - JULIA_VERSION=1.0.0  # test three-digit version
+  - JULIA_VERSION=1.1    # newest support
+  - JULIA_VERSION=nightly
+
+notifications:
+  email: false
+
+before_script:
+  - ./install-julia.sh "$JULIA_VERSION"
+
+script:
+  - julia -e "Base.banner()"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Julia installer shell script for CI
+
+[![Build Status](https://travis-ci.org/JuliaCI/install-julia.svg?branch=master)](https://travis-ci.org/JuliaCI/install-julia)


### PR DESCRIPTION
This PR adds Travis CI setting for testing the installer script.

It seems that the setting is working: https://travis-ci.com/tkf/install-julia/builds/101202646

~Can someone in @JuliaCI activate Travis?~ (I didn't realize I could activate it: https://travis-ci.org/JuliaCI/install-julia/builds/494663637)