### PR TITLE
Deprecate repo, and point users to `julia-actions/setup-julia`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Julia installer shell script for CI
+This repository is deprecated.
 
-[![Build Status](https://travis-ci.org/JuliaCI/install-julia.svg?branch=master)](https://travis-ci.org/JuliaCI/install-julia)
+If you are using GitHub Actions CI, and you want to install Julia inside CI, see: [`julia-actions/setup-julia`](https://github.com/julia-actions/setup-julia)


### PR DESCRIPTION
Travis has been dead for a while (for open-source projects), and most folks have migrated to GHA.